### PR TITLE
Remove webKitAudioContext

### DIFF
--- a/dist/p5.gibber.js
+++ b/dist/p5.gibber.js
@@ -6846,9 +6846,7 @@ Create a callback and start it running. Note that in iOS audio callbacks can onl
         audioContext,
         start
     
-    if( typeof webkitAudioContext !== 'undefined' ) {
-      audioContext = webkitAudioContext
-    }else if ( typeof AudioContext !== 'undefined' ) {
+    if ( typeof AudioContext !== 'undefined' ) {
       audioContext = AudioContext
     }
 


### PR DESCRIPTION
Removes webkit audio context as per https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Migrating_from_webkitAudioContext

This fix allows a sketch working on latest Chrome to run. Otherwise you will get the error:

`p5.gibber.js:6874 The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page.`